### PR TITLE
Remove detailed answers from result page

### DIFF
--- a/templates/result.html
+++ b/templates/result.html
@@ -3,16 +3,6 @@
 {% block content %}
 <h1>Спасибо, {{ name }}!</h1>
 <p>Ваш результат: <strong>{{ correct }}</strong> из <strong>{{ total }}</strong></p>
-{% if detailed %}
-  <details>
-    <summary>Посмотреть ответы</summary>
-    <ul>
-      {% for item in detailed %}
-        <li>{{ loop.index }}. {{ item.filename }} — ваш ответ: {{ 'Спам' if item.user_answer == 'spam' else 'Не спам' }} ({{ 'верно' if item.is_correct else 'ошибка' }})</li>
-      {% endfor %}
-    </ul>
-  </details>
-{% endif %}
 <form method="post" action="{{ url_for('restart') }}">
   <button type="submit" class="secondary">Пройти снова</button>
 </form>


### PR DESCRIPTION
## Summary
- remove the collapsible detailed answers section from the quiz results page
- keep only the thank-you message and overall score

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e76c2043088333ba67e29fb793ceb7